### PR TITLE
Update lexical-conventions.md

### DIFF
--- a/docs/cpp/lexical-conventions.md
+++ b/docs/cpp/lexical-conventions.md
@@ -36,7 +36,7 @@ ms.locfileid: "62216397"
 
 - [사용자 정의 리터럴](../cpp/user-defined-literals-cpp.md)
 
-## <a name="see-also"></a>참고 항목
+## <a name="see-also"></a>참고 자료
 
 [C++ 언어 참조](../cpp/cpp-language-reference.md)<br/>
 [프로그램 및 링크](program-and-linkage-cpp.md)


### PR DESCRIPTION
All other pages are using "참고 자료". Below are some example pages. If you want to use "참고 항목", you will have to replace all pages with "참고 항목". Both "참고 자료" and "참고 항목" are correct words.
https://docs.microsoft.com/ko-kr/cpp/cpp/tokens-cpp?view=vs-2019
https://docs.microsoft.com/ko-kr/cpp/cpp/identifiers-cpp?view=vs-2019
https://docs.microsoft.com/ko-kr/cpp/cpp/keywords-cpp?view=vs-2019
https://docs.microsoft.com/ko-kr/cpp/cpp/numeric-boolean-and-pointer-literals-cpp?view=vs-2019
https://docs.microsoft.com/ko-kr/cpp/cpp/string-and-character-literals-cpp?view=vs-2019
https://docs.microsoft.com/ko-kr/cpp/cpp/overview-of-file-translation?view=vs-2019