### PR TITLE
Update auto-keyword.md

### DIFF
--- a/docs/cpp/auto-keyword.md
+++ b/docs/cpp/auto-keyword.md
@@ -30,6 +30,6 @@ auto declarator initializer;
 
 - [/Zc: auto(변수 형식 추론)](../build/reference/zc-auto-deduce-variable-type.md)은 사용할 **auto** 키워드의 정의를 컴파일러에 알리는 컴파일러 옵션을 설명합니다.
 
-## <a name="see-also"></a>참고 항목
+## <a name="see-also"></a>참고 자료
 
 [C++ 키워드](../cpp/keywords-cpp.md)


### PR DESCRIPTION
All other pages are using "참고 자료". Below are some example pages. If you want to use "참고 항목", you will have to replace all pages with "참고 항목". Both "참고 자료" and "참고 항목" are correct words.
https://docs.microsoft.com/ko-kr/cpp/cpp/tokens-cpp?view=vs-2019
https://docs.microsoft.com/ko-kr/cpp/cpp/identifiers-cpp?view=vs-2019
https://docs.microsoft.com/ko-kr/cpp/cpp/keywords-cpp?view=vs-2019
https://docs.microsoft.com/ko-kr/cpp/cpp/numeric-boolean-and-pointer-literals-cpp?view=vs-2019
https://docs.microsoft.com/ko-kr/cpp/cpp/string-and-character-literals-cpp?view=vs-2019
https://docs.microsoft.com/ko-kr/cpp/cpp/overview-of-file-translation?view=vs-2019