### PR TITLE
Update custom-manipulators-with-arguments.md

### DIFF
--- a/docs/standard-library/custom-manipulators-with-arguments.md
+++ b/docs/standard-library/custom-manipulators-with-arguments.md
@@ -23,6 +23,6 @@ ms.locfileid: "68460048"
 
 [다른 하나의 인수를 사용하는 출력 스트림 조작자](../standard-library/other-one-argument-output-stream-manipulators.md)
 
-## <a name="see-also"></a>참고 항목
+## <a name="see-also"></a>참고 자료
 
 [iostream 프로그래밍](../standard-library/iostream-programming.md)


### PR DESCRIPTION
All other pages are using "참고자료". Below are some example pages. If you want to use "참고 항목", you will have to replace all pages with "참고 항목". Both "참고자료" and "참고 항목" are correct words.

https://docs.microsoft.com/ko-kr/cpp/standard-library/output-stream-manipulators-with-one-argument-int-or-long?view=vs-2019
https://docs.microsoft.com/ko-kr/cpp/standard-library/other-one-argument-output-stream-manipulators?view=vs-2019